### PR TITLE
docs: desearch.js SDK knowledge base and README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,393 +1,318 @@
-# Desearch
+# desearch.js
 
-The official JavaScript SDK for the Desearch API - AI-driven search, web crawling, and X (Twitter) data extraction.
+Official JavaScript and TypeScript SDK for the Desearch API.
 
-## Table of Contents
+It publishes to npm as `desearch-js` and the current package version in this repo is `1.3.0`.
 
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [AI Contextual Search](#ai-contextual-search)
-- [AI Web Links Search](#ai-web-links-search)
-- [AI X Posts Links Search](#ai-x-posts-links-search)
-- [X Search](#x-search)
-- [Fetch Posts by URLs](#fetch-posts-by-urls)
-- [Retrieve Post by ID](#retrieve-post-by-id)
-- [Search X Posts by User](#search-x-posts-by-user)
-- [Get Retweeters of a Post](#get-retweeters-of-a-post)
-- [Get X Posts by Username](#get-x-posts-by-username)
-- [Fetch User's Tweets and Replies](#fetch-users-tweets-and-replies)
-- [Retrieve Replies for a Post](#retrieve-replies-for-a-post)
-- [Get X Trends](#get-x-trends)
-- [SERP Web Search](#serp-web-search)
-- [Crawl a URL](#crawl-a-url)
-- [Links](#links)
-
-## Installation
+## Install
 
 ```bash
 npm install desearch-js
 ```
 
-## Quick Start
+## What this SDK covers
 
-```typescript
-import Desearch from "desearch-js";
+The SDK wraps the public Desearch API for:
+- AI multi-source search
+- AI link retrieval for web sources and X posts
+- X data search and retrieval
+- Web SERP search
+- Web crawling
 
-const desearch = new Desearch("your-api-key");
+See also:
+- [docs/features.md](./docs/features.md)
+- [docs/architecture.md](./docs/architecture.md)
+- [docs/known-issues.md](./docs/known-issues.md)
 
-// Perform an AI-powered search
-desearch
-  .aiSearch({
-    prompt: "Latest developments in AI",
-    tools: ["web", "twitter", "reddit"],
-  })
-  .then((response) => {
-    console.log(response);
-  });
+## Import styles
+
+### ESM
+
+```ts
+import Desearch from 'desearch-js';
+
+const client = new Desearch(process.env.DESEARCH_API_KEY!);
 ```
 
-## AI Contextual Search
+### CommonJS
 
-`aiSearch`
+```js
+const Desearch = require('desearch-js');
 
-AI-powered multi-source contextual search. Searches across web, X (Twitter), Reddit, YouTube, HackerNews, Wikipedia, and arXiv and returns results with optional AI-generated summaries.
-
-| Parameter                | Type                     | Required | Default                      | Description                                                |
-| ------------------------ | ------------------------ | -------- | ---------------------------- | ---------------------------------------------------------- |
-| `prompt`                 | `string`                 | Yes      | —                            | Search query prompt                                        |
-| `tools`                  | `(ToolEnum \| string)[]` | Yes      | —                            | A list of tools to be used for the search                  |
-| `start_date`             | `string \| null`         | No       | `null`                       | The start date for the search query (YYYY-MM-DDTHH:MM:SSZ) |
-| `end_date`               | `string \| null`         | No       | `null`                       | The end date for the search query (YYYY-MM-DDTHH:MM:SSZ)   |
-| `date_filter`            | `DateFilterEnum \| null` | No       | `'PAST_24_HOURS'`            | Predefined date filter for search results                  |
-| `result_type`            | `ResultTypeEnum \| null` | No       | `'LINKS_WITH_FINAL_SUMMARY'` | The result type for the search                             |
-| `system_message`         | `string \| null`         | No       | `''`                         | System message for the search                              |
-| `scoring_system_message` | `string \| null`         | No       | `null`                       | System message for scoring the response                    |
-| `count`                  | `number \| null`         | No       | `10`                         | Number of results per source (10–200)                      |
-
-```typescript
-desearch
-  .aiSearch({
-    prompt: "Bittensor",
-    tools: ["web", "hackernews", "reddit", "wikipedia", "youtube", "twitter", "arxiv"],
-    date_filter: "PAST_24_HOURS",
-    result_type: "LINKS_WITH_FINAL_SUMMARY",
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+const client = new Desearch(process.env.DESEARCH_API_KEY);
 ```
 
-## AI Web Links Search
+The package exports both module formats from `dist/`:
+- CommonJS entry: `./dist/index.js`
+- ESM entry: `./dist/index.mjs`
+- Type declarations: `./dist/index.d.ts`
 
-`aiWebLinksSearch`
+## Quick start
 
-Search for raw links across web sources (web, HackerNews, Reddit, Wikipedia, YouTube, arXiv). Returns structured link results without AI summaries.
+```ts
+import Desearch from 'desearch-js';
 
-| Parameter | Type                        | Required | Default | Description                           |
-| --------- | --------------------------- | -------- | ------- | ------------------------------------- |
-| `prompt`  | `string`                    | Yes      | —       | Search query prompt                   |
-| `tools`   | `(WebToolEnum \| string)[]` | Yes      | —       | List of tools to search with          |
-| `count`   | `number \| null`            | No       | `10`    | Number of results per source (10–200) |
+const client = new Desearch(process.env.DESEARCH_API_KEY!);
 
-```typescript
-desearch
-  .aiWebLinksSearch({
-    prompt: "What are the recent sport events?",
-    tools: ["web", "hackernews", "reddit", "wikipedia", "youtube", "arxiv"],
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+const result = await client.aiSearch({
+  prompt: 'latest Bittensor developments',
+  tools: ['web', 'twitter', 'reddit'],
+  date_filter: 'PAST_24_HOURS',
+  result_type: 'LINKS_WITH_FINAL_SUMMARY',
+  count: 10,
+});
+
+console.log(result);
 ```
 
-## AI X Posts Links Search
+## Authentication
 
-`aiXLinksSearch`
+Construct the client with your Desearch API key:
 
-Search for X (Twitter) post links matching a prompt using AI-powered models. Returns tweet objects from the miner network.
-
-| Parameter | Type             | Required | Default | Description                           |
-| --------- | ---------------- | -------- | ------- | ------------------------------------- |
-| `prompt`  | `string`         | Yes      | —       | Search query prompt                   |
-| `count`   | `number \| null` | No       | `10`    | Number of results per source (10–200) |
-
-```typescript
-desearch
-  .aiXLinksSearch({
-    prompt: "What are the recent sport events?",
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const client = new Desearch('your-api-key');
 ```
 
-## X Search
+Requests send the key in the `Authorization` header.
 
-`xSearch`
+## API surface
 
-X (Twitter) search with extensive filtering options: date range, user, language, verification status, media type (image/video/quote), and engagement thresholds (min likes, retweets, replies). Sort by Top or Latest.
+### AI search
 
-| Parameter       | Type                       | Required | Default | Description                              |
-| --------------- | -------------------------- | -------- | ------- | ---------------------------------------- |
-| `query`         | `string`                   | Yes      | —       | Advanced search query                    |
-| `sort`          | `string \| null`           | No       | `'Top'` | Sort by Top or Latest                    |
-| `user`          | `string \| null`           | No       | `null`  | User to search for                       |
-| `start_date`    | `string \| null`           | No       | `null`  | Start date in UTC (YYYY-MM-DD)           |
-| `end_date`      | `string \| null`           | No       | `null`  | End date in UTC (YYYY-MM-DD)             |
-| `lang`          | `string \| null`           | No       | `null`  | Language code (e.g., en, es, fr)         |
-| `verified`      | `boolean \| null`          | No       | `null`  | Filter for verified users                |
-| `blue_verified` | `boolean \| null`          | No       | `null`  | Filter for blue checkmark verified users |
-| `is_quote`      | `boolean \| null`          | No       | `null`  | Include only tweets with quotes          |
-| `is_video`      | `boolean \| null`          | No       | `null`  | Include only tweets with videos          |
-| `is_image`      | `boolean \| null`          | No       | `null`  | Include only tweets with images          |
-| `min_retweets`  | `number \| string \| null` | No       | `null`  | Minimum number of retweets               |
-| `min_replies`   | `number \| string \| null` | No       | `null`  | Minimum number of replies                |
-| `min_likes`     | `number \| string \| null` | No       | `null`  | Minimum number of likes                  |
-| `count`         | `number \| null`           | No       | `20`    | Number of tweets to retrieve (1–100)     |
+#### `aiSearch(payload)`
 
-```typescript
-desearch
-  .xSearch({
-    query: "Whats going on with Bittensor",
-    sort: "Top",
-    user: "elonmusk",
-    start_date: "2024-12-01",
-    end_date: "2025-02-25",
-    lang: "en",
-    verified: true,
-    blue_verified: true,
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+Runs the multi-source AI search endpoint at `POST /desearch/ai/search`.
+
+Supported request fields:
+- `prompt` (required)
+- `tools` (required): `web`, `hackernews`, `reddit`, `wikipedia`, `youtube`, `twitter`, `arxiv`
+- `start_date`
+- `end_date`
+- `date_filter`: `PAST_24_HOURS`, `PAST_2_DAYS`, `PAST_WEEK`, `PAST_2_WEEKS`, `PAST_MONTH`, `PAST_2_MONTHS`, `PAST_YEAR`, `PAST_2_YEARS`
+- `result_type`: `ONLY_LINKS`, `LINKS_WITH_FINAL_SUMMARY`
+- `system_message`
+- `scoring_system_message`
+- `count`
+
+Notes:
+- The SDK strips any incoming `streaming` flag and always sends `streaming: false`.
+- Response type is broad and may be structured JSON or a string depending on the API response.
+
+```ts
+const result = await client.aiSearch({
+  prompt: 'recent AI chip announcements',
+  tools: ['web', 'hackernews', 'reddit', 'twitter'],
+  result_type: 'LINKS_WITH_FINAL_SUMMARY',
+  count: 20,
+});
 ```
 
-## Fetch Posts by URLs
+#### `aiWebLinksSearch(payload)`
 
-`xPostsByUrls`
+Runs `POST /desearch/ai/search/links/web` for web-only link retrieval.
 
-Fetch full post data for a list of X (Twitter) post URLs. Returns metadata, content, and engagement metrics for each URL.
-
-| Parameter | Type       | Required | Default | Description                   |
-| --------- | ---------- | -------- | ------- | ----------------------------- |
-| `urls`    | `string[]` | Yes      | —       | List of post URLs to retrieve |
-
-```typescript
-desearch
-  .xPostsByUrls({
-    urls: ["https://x.com/RacingTriple/status/1892527552029499853"],
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const result = await client.aiWebLinksSearch({
+  prompt: 'open source browser automation tools',
+  tools: ['web', 'hackernews', 'reddit', 'youtube'],
+  count: 20,
+});
 ```
 
-## Retrieve Post by ID
+#### `aiXLinksSearch(payload)`
 
-`xPostById`
+Runs `POST /desearch/ai/search/links/twitter` for AI-assisted X link retrieval.
 
-Fetch a single X (Twitter) post by its unique ID. Returns metadata, content, and engagement metrics.
-
-| Parameter | Type     | Required | Default | Description               |
-| --------- | -------- | -------- | ------- | ------------------------- |
-| `id`      | `string` | Yes      | —       | The unique ID of the post |
-
-```typescript
-desearch
-  .xPostById({
-    id: "1892527552029499853",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const result = await client.aiXLinksSearch({
+  prompt: 'Bittensor subnet updates',
+  count: 20,
+});
 ```
 
-## Search X Posts by User
+### X endpoints
 
-`xPostsByUser`
+#### `xSearch(params)`
 
-Search X (Twitter) posts by a specific user, with optional keyword filtering.
+Runs `GET /twitter`.
 
-| Parameter | Type     | Required | Default | Description                          |
-| --------- | -------- | -------- | ------- | ------------------------------------ |
-| `user`    | `string` | Yes      | —       | User to search for                   |
-| `query`   | `string` | No       | `''`    | Advanced search query                |
-| `count`   | `number` | No       | `10`    | Number of tweets to retrieve (1–100) |
+Useful filters include:
+- `query`
+- `sort`
+- `user`
+- `start_date`, `end_date`
+- `lang`
+- `verified`, `blue_verified`
+- `is_quote`, `is_video`, `is_image`
+- `min_retweets`, `min_replies`, `min_likes`
+- `count`
 
-```typescript
-desearch
-  .xPostsByUser({
-    user: "elonmusk",
-    query: "Whats going on with Bittensor",
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const tweets = await client.xSearch({
+  query: 'bittensor',
+  sort: 'Top',
+  lang: 'en',
+  min_likes: 50,
+  count: 20,
+});
 ```
 
-## Get Retweeters of a Post
+#### `xPostsByUrls(params)`
 
-`xPostRetweeters`
+Runs `GET /twitter/urls`.
 
-Retrieve the list of users who retweeted a specific post by its ID. Supports cursor-based pagination.
-
-| Parameter | Type             | Required | Default | Description                              |
-| --------- | ---------------- | -------- | ------- | ---------------------------------------- |
-| `id`      | `string`         | Yes      | —       | The ID of the post to get retweeters for |
-| `cursor`  | `string \| null` | No       | `null`  | Cursor for pagination                    |
-
-```typescript
-desearch
-  .xPostRetweeters({
-    id: "1982770537081532854",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const tweets = await client.xPostsByUrls({
+  urls: ['https://x.com/DesearchAI/status/1234567890123456789'],
+});
 ```
 
-## Get X Posts by Username
+#### `xPostById(params)`
 
-`xUserPosts`
+Runs `GET /twitter/post`.
 
-Retrieve a user's timeline posts by their username. Fetches the latest tweets posted by that user. Supports cursor-based pagination.
-
-| Parameter  | Type             | Required | Default | Description                 |
-| ---------- | ---------------- | -------- | ------- | --------------------------- |
-| `username` | `string`         | Yes      | —       | Username to fetch posts for |
-| `cursor`   | `string \| null` | No       | `null`  | Cursor for pagination       |
-
-```typescript
-desearch
-  .xUserPosts({
-    username: "elonmusk",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const tweet = await client.xPostById({
+  id: '1234567890123456789',
+});
 ```
 
-## Fetch User's Tweets and Replies
+#### `xPostsByUser(params)`
 
-`xUserReplies`
+Runs `GET /twitter/post/user`.
 
-Fetch tweets and replies posted by a specific user, with optional keyword filtering.
-
-| Parameter | Type     | Required | Default | Description                            |
-| --------- | -------- | -------- | ------- | -------------------------------------- |
-| `user`    | `string` | Yes      | —       | The username of the user to search for |
-| `count`   | `number` | No       | `10`    | The number of tweets to fetch (1–100)  |
-| `query`   | `string` | No       | `''`    | Advanced search query                  |
-
-```typescript
-desearch
-  .xUserReplies({
-    user: "elonmusk",
-    count: 20,
-    query: "latest news on AI",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const tweets = await client.xPostsByUser({
+  user: 'DesearchAI',
+  query: 'launch',
+  count: 10,
+});
 ```
 
-## Retrieve Replies for a Post
+#### `xPostRetweeters(params)`
 
-`xPostReplies`
+Runs `GET /twitter/post/retweeters`.
 
-Fetch replies to a specific X (Twitter) post by its post ID.
-
-| Parameter | Type     | Required | Default | Description                           |
-| --------- | -------- | -------- | ------- | ------------------------------------- |
-| `post_id` | `string` | Yes      | —       | The ID of the post to search for      |
-| `count`   | `number` | No       | `10`    | The number of tweets to fetch (1–100) |
-| `query`   | `string` | No       | `''`    | Advanced search query                 |
-
-```typescript
-desearch
-  .xPostReplies({
-    post_id: "1234567890",
-    count: 20,
-    query: "latest news on AI",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const retweeters = await client.xPostRetweeters({
+  id: '1234567890123456789',
+});
 ```
 
-## Get X Trends
+#### `xUserPosts(params)`
 
-`xTrends`
+Runs `GET /twitter/user/posts`.
 
-Retrieve trending topics on X for a given location using its WOEID (Where On Earth ID).
-
-| Parameter | Type             | Required | Default | Description                                                 |
-| --------- | ---------------- | -------- | ------- | ----------------------------------------------------------- |
-| `woeid`   | `number`         | Yes      | —       | The WOEID of the location (e.g. 23424977 for United States) |
-| `count`   | `number \| null` | No       | `30`    | The number of trends to return (30–100)                     |
-
-```typescript
-desearch
-  .xTrends({
-    woeid: 23424977,
-    count: 20,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const timeline = await client.xUserPosts({
+  username: 'DesearchAI',
+});
 ```
 
-## SERP Web Search
+#### `xUserReplies(params)`
 
-`webSearch`
+Runs `GET /twitter/replies`.
 
-SERP web search. Returns paginated web search results, replicating a typical search engine experience.
-
-| Parameter | Type     | Required | Default | Description                                               |
-| --------- | -------- | -------- | ------- | --------------------------------------------------------- |
-| `query`   | `string` | Yes      | —       | The search query string                                   |
-| `start`   | `number` | No       | `0`     | How many results to skip for pagination (0, 10, 20, etc.) |
-
-```typescript
-desearch
-  .webSearch({
-    query: "latest news on AI",
-    start: 10,
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const replies = await client.xUserReplies({
+  user: 'DesearchAI',
+  count: 20,
+});
 ```
 
-## Crawl a URL
+#### `xPostReplies(params)`
 
-`webCrawl`
+Runs `GET /twitter/replies/post`.
 
-Crawl a URL and return its content as plain text or HTML.
-
-| Parameter | Type               | Required | Default  | Description                          |
-| --------- | ------------------ | -------- | -------- | ------------------------------------ |
-| `url`     | `string`           | Yes      | —        | URL to crawl                         |
-| `format`  | `'html' \| 'text'` | No       | `'text'` | Format of the content to be returned |
-
-```typescript
-desearch
-  .webCrawl({
-    url: "https://en.wikipedia.org/wiki/Artificial_intelligence",
-    format: "html",
-  })
-  .then((result) => {
-    console.log(result);
-  });
+```ts
+const replies = await client.xPostReplies({
+  post_id: '1234567890123456789',
+  count: 20,
+});
 ```
+
+#### `xTrends(params)`
+
+Runs `GET /twitter/trends`.
+
+```ts
+const trends = await client.xTrends({
+  woeid: 23424977,
+  count: 30,
+});
+```
+
+### Web endpoints
+
+#### `webSearch(params)`
+
+Runs `GET /web`.
+
+```ts
+const results = await client.webSearch({
+  query: 'site:desearch.ai sdk docs',
+  start: 0,
+});
+```
+
+#### `webCrawl(params)`
+
+Runs `GET /web/crawl` and returns text or HTML as a string.
+
+```ts
+const page = await client.webCrawl({
+  url: 'https://desearch.ai',
+  format: 'text',
+});
+```
+
+## TypeScript
+
+The package ships its own declaration file and exports request and response shapes from `src/types.ts` into the generated `dist/index.d.ts` bundle.
+
+Important exported type families include:
+- search request types
+- X request and response types
+- web search and crawl types
+- detailed `TwitterScraperTweet` and `TwitterScraperUser` models
+- error payload types such as `HTTPValidationError`
+
+## Error handling
+
+Non-2xx responses throw `Error` with the format:
+
+```txt
+HTTP <status>: <response body>
+```
+
+Other failures are wrapped as:
+
+```txt
+Unexpected Error: <message>
+```
+
+Example:
+
+```ts
+try {
+  await client.webSearch({ query: 'desearch' });
+} catch (error) {
+  console.error(error);
+}
+```
+
+## Development
+
+Available scripts from `package.json`:
+- `npm run build`
+- `npm run build-fast`
+- `npm test`
+- `npm run generate-docs`
+- `npm run publish:beta`
+- `npm run publish:stable`
 
 ## Links
 
-- [Desearch](https://desearch.ai)
-- [API Console](https://console.desearch.ai)
-- [API Reference](https://desearch.ai/docs/api-reference/)
+- <https://github.com/Desearch-ai/desearch.js>
+- <https://desearch.ai>
+- <https://console.desearch.ai>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ See also:
 - [docs/architecture.md](./docs/architecture.md)
 - [docs/known-issues.md](./docs/known-issues.md)
 
+## Documentation map
+
+- `README.md`: install, imports, auth, method usage, packaging, and error behavior
+- `docs/features.md`: SDK capability and method-by-method status inventory
+- `docs/architecture.md`: request flow, async model, type layout, and packaging structure
+- `docs/known-issues.md`: current limitations and integration caveats visible from source
+
 ## Import styles
 
 ### ESM
@@ -76,6 +83,11 @@ const client = new Desearch('your-api-key');
 Requests send the key in the `Authorization` header.
 
 ## API surface
+
+Method index:
+- AI search: `aiSearch`, `aiWebLinksSearch`, `aiXLinksSearch`
+- X data: `xSearch`, `xPostsByUrls`, `xPostById`, `xPostsByUser`, `xPostRetweeters`, `xUserPosts`, `xUserReplies`, `xPostReplies`, `xTrends`
+- Web: `webSearch`, `webCrawl`
 
 ### AI search
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,252 @@
+# desearch.js architecture
+
+## Overview
+
+`desearch.js` is a small API wrapper centered around a single `Desearch` class in `src/index.ts`.
+
+The architecture is intentionally thin:
+- one client class
+- one internal request helper
+- one shared type module
+- generated dist output for CommonJS, ESM, and declarations
+
+This keeps the package small and easy to audit, but it also means most behavior is delegated directly to the upstream API.
+
+## Module layout
+
+- `src/index.ts`: client implementation and exported default class
+- `src/types.ts`: request, response, entity, and error interfaces
+- `package.json`: package exports, scripts, and publish configuration
+- `tsup.config.ts`: build pipeline configuration for `dist/`
+
+## Client design
+
+The public entry point is:
+
+```ts
+class Desearch {
+  private baseURL: string;
+  private apiKey: string;
+}
+```
+
+### Construction
+
+The constructor takes one value:
+- `apiKey: string`
+
+At construction time the class stores:
+- `baseURL = 'https://api.desearch.ai'`
+- `apiKey`
+
+The base URL is fixed inside the SDK rather than configured per instance.
+
+## Request pipeline
+
+All public methods delegate to a single private helper:
+
+```ts
+private async handleRequest<T>(method: string, path: string, payload?: unknown): Promise<T>
+```
+
+That helper is responsible for:
+- building the final request URL from `baseURL + path`
+- attaching the `Authorization` header with the raw API key
+- serializing GET payloads into `URLSearchParams`
+- serializing POST payloads with `JSON.stringify`
+- selecting JSON parsing vs text parsing from the response `content-type`
+- normalizing thrown errors
+
+### GET requests
+
+For GET methods, the helper:
+- ignores `undefined` and `null` values
+- appends scalar values as query params
+- appends arrays by repeating the same key multiple times
+
+That repeated-key behavior matters for calls like `xPostsByUrls`, where `urls` is sent as a GET query array.
+
+### POST requests
+
+For POST methods, the helper:
+- sets `Content-Type: application/json`
+- sends the payload as a JSON string body
+
+### Response parsing
+
+If the response content type contains `application/json`, the SDK returns `await response.json()`.
+
+Otherwise it falls back to `await response.text()`.
+
+This is why `webCrawl` returns `Promise<string>` even though most other methods return JSON-shaped data.
+
+### Error model
+
+The helper distinguishes between HTTP failures and other exceptions:
+- HTTP failures become `Error('HTTP <status>: <body>')`
+- all other failures become `Error('Unexpected Error: <message>')`
+
+There are type definitions for common API error payloads in `src/types.ts`, but they are not instantiated as typed runtime error classes.
+
+## Async design
+
+Every SDK method is asynchronous and returns a `Promise`.
+
+There is no internal queue, retry layer, or cancellation abstraction. The async model is just direct request-response execution on top of `undici`'s `fetch`.
+
+Implications:
+- callers own concurrency control
+- callers own retry strategy
+- callers own timeout strategy
+- callers can use `await` or standard promise chaining
+
+### `aiSearch` special case
+
+`aiSearch` is the only method with extra request shaping.
+
+It removes any incoming `streaming` field from the caller payload and always sends:
+
+```json
+{ "streaming": false }
+```
+
+That means the current client intentionally forces non-streaming behavior even if upstream API support expands.
+
+## Public API structure
+
+The class groups naturally into three areas.
+
+### AI search methods
+
+- `aiSearch`
+- `aiWebLinksSearch`
+- `aiXLinksSearch`
+
+These use POST requests and structured JSON bodies.
+
+### X data methods
+
+- `xSearch`
+- `xPostsByUrls`
+- `xPostById`
+- `xPostsByUser`
+- `xPostRetweeters`
+- `xUserPosts`
+- `xUserReplies`
+- `xPostReplies`
+- `xTrends`
+
+These use GET requests with query-string serialization.
+
+### Web methods
+
+- `webSearch`
+- `webCrawl`
+
+These are also GET requests.
+
+## TypeScript type system
+
+`src/types.ts` is the schema backbone of the SDK.
+
+It provides four main type layers.
+
+### 1. Literal types and enums
+
+These constrain common API fields:
+- `ToolEnum`
+- `WebToolEnum`
+- `DateFilterEnum`
+- `ResultTypeEnum`
+
+These are string literal unions, not runtime enums, so they disappear at build time and keep bundle overhead low.
+
+### 2. Request contracts
+
+Each public method takes a matching request interface. Examples:
+- `AiSearchRequest`
+- `XSearchParams`
+- `WebCrawlParams`
+
+This keeps the call sites strongly typed for TypeScript consumers.
+
+### 3. Response contracts
+
+The SDK models both high-level and endpoint-specific responses, including:
+- aggregated search response shapes
+- web result collections
+- X timeline and retweeter collections
+- trends responses
+
+One deliberate weak spot is `AiSearchResponse`, which remains permissive because the upstream response can vary.
+
+### 4. Rich X entity models
+
+The largest share of the type file documents nested tweet and user data:
+- tweet metadata
+- media payloads
+- entities and mentions
+- profile metadata
+- professional categories
+- pagination cursors
+
+This is the most structurally detailed part of the SDK.
+
+## Packaging and distribution
+
+`package.json` configures the package for npm distribution.
+
+Key packaging details:
+- package name: `desearch-js`
+- current version: `1.3.0`
+- public npm publish config
+- `main`: `./dist/index.js`
+- `module`: `./dist/index.mjs`
+- `types`: `./dist/index.d.ts`
+- conditional `exports` for `require` and `import`
+
+This gives consumers:
+- CommonJS compatibility
+- ESM compatibility
+- bundled type declarations
+
+## Build system
+
+The repo uses `tsup` to compile `src/index.ts` into distributable artifacts.
+
+Relevant scripts:
+- `build-fast`: cjs + esm
+- `build`: default tsup build
+- `generate-docs`: TypeDoc markdown output
+- `test`: Vitest run
+
+The package is small enough that there is no multi-package workspace, code generation layer, or custom runtime transport abstraction.
+
+## Architectural tradeoffs
+
+### Strengths
+
+- very small surface area
+- easy to read and maintain
+- good TypeScript coverage for payloads and X entities
+- dual-module packaging is already in place
+
+### Limitations
+
+- hard-coded production base URL
+- no transport customization hooks
+- no middleware or interceptors
+- no streaming implementation
+- no typed runtime error classes
+- no retries, backoff, timeout configuration, or abort support surfaced by the class
+
+## Recommended mental model
+
+Treat `desearch.js` as a typed convenience wrapper around the HTTP API, not as a heavy SDK framework.
+
+It is best for:
+- server-side Node usage
+- scripts and backend services
+- apps that want typed request payloads and response shapes with minimal abstraction
+
+If you need advanced transport control, you currently have to add it outside the SDK or change the client implementation itself.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,97 @@
+# desearch.js features
+
+Source basis for this inventory:
+- `src/index.ts`
+- `src/types.ts`
+- `package.json`
+
+Status legend:
+- ✅ working
+- ⚠️ degraded or has caveats
+- ❌ broken or missing
+- 🚧 in progress
+
+## Package-level capabilities
+
+- ✅ Published npm package: `desearch-js`
+- ✅ Current repo version: `1.3.0`
+- ✅ Dual output build: CommonJS + ESM
+- ✅ Bundled TypeScript declarations
+- ✅ Generated API docs support via TypeDoc
+- ⚠️ No endpoint-specific runtime validation in the client
+- ⚠️ No retry, timeout, or backoff controls exposed by the SDK
+- ⚠️ No streaming support even though `aiSearch` explicitly handles a `streaming` field
+
+## Public SDK method inventory
+
+| Method | Endpoint | Status | Notes |
+| --- | --- | --- | --- |
+| `aiSearch` | `POST /desearch/ai/search` | ⚠️ | Core AI search works through a JSON POST, but the SDK forcibly sends `streaming: false` and does not expose streaming responses. |
+| `aiWebLinksSearch` | `POST /desearch/ai/search/links/web` | ✅ | Straight wrapper around the web links endpoint. |
+| `aiXLinksSearch` | `POST /desearch/ai/search/links/twitter` | ✅ | Straight wrapper around the X links endpoint. |
+| `xSearch` | `GET /twitter` | ✅ | Supports broad query-string filters, including arrays and booleans via `URLSearchParams`. |
+| `xPostsByUrls` | `GET /twitter/urls` | ⚠️ | Accepts repeated `urls` query params; behavior depends on server support for repeated keys in GET requests. |
+| `xPostById` | `GET /twitter/post` | ✅ | Single-post fetch wrapper. |
+| `xPostsByUser` | `GET /twitter/post/user` | ✅ | User-scoped post search with optional keyword filter. |
+| `xPostRetweeters` | `GET /twitter/post/retweeters` | ✅ | Supports pagination with `cursor`. |
+| `xUserPosts` | `GET /twitter/user/posts` | ✅ | Returns user profile plus timeline tweets and optional cursor. |
+| `xUserReplies` | `GET /twitter/replies` | ✅ | Fetches a user's tweets and replies. |
+| `xPostReplies` | `GET /twitter/replies/post` | ✅ | Fetches replies for a target post. |
+| `xTrends` | `GET /twitter/trends` | ✅ | WOEID-based trends lookup. |
+| `webSearch` | `GET /web` | ✅ | Simple SERP-style wrapper with pagination offset. |
+| `webCrawl` | `GET /web/crawl` | ✅ | Returns raw text or HTML as a string instead of JSON. |
+
+## Type coverage
+
+### Search request types
+
+- ✅ `AiSearchRequest`
+- ✅ `AiWebLinksSearchRequest`
+- ✅ `AiXLinksSearchRequest`
+- ✅ `WebSearchParams`
+- ✅ `WebCrawlParams`
+
+### Search response types
+
+- ⚠️ `AiSearchResponse` is intentionally broad: `ResponseData | Record<string, unknown> | string`
+- ✅ `WebSearchResponse`
+- ✅ `XLinksSearchResponse`
+- ✅ `WebSearchResultsResponse`
+
+### X request and response types
+
+- ✅ `XSearchParams`
+- ✅ `XPostsByUrlsParams`
+- ✅ `XPostByIdParams`
+- ✅ `XPostsByUserParams`
+- ✅ `XPostRetweetersParams`
+- ✅ `XUserPostsParams`
+- ✅ `XUserRepliesParams`
+- ✅ `XPostRepliesParams`
+- ✅ `XTrendsParams`
+- ✅ `XRetweetersResponse`
+- ✅ `XUserPostsResponse`
+- ✅ `XTrendsResponse`
+
+### Detailed X models
+
+- ✅ `TwitterScraperTweet`
+- ✅ `TwitterScraperUser`
+- ✅ media, entity, professional, and nested response sub-types
+
+### Error models
+
+- ✅ `UnauthorizedResponse`
+- ✅ `TooManyRequestsResponse`
+- ✅ `InternalServerErrorResponse`
+- ✅ `MovedPermanentlyResponse`
+- ✅ `HTTPValidationError`
+- ✅ `ValidationError`
+
+## Practical gaps to know before using the SDK
+
+- ⚠️ The constructor only accepts an API key and does not allow overriding `baseURL`.
+- ⚠️ The client returns plain thrown `Error` objects rather than typed SDK error classes.
+- ⚠️ There are no helper abstractions for pagination, rate limiting, or auto-retry.
+- ⚠️ The package is Node-oriented and uses `undici` directly.
+- ❌ No upload, mutation, or write endpoints are exposed in this repo.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,94 @@
+# desearch.js known issues and limitations
+
+This document only lists issues that are visible from the current repository state.
+
+## 1. `aiSearch` does not support streaming
+
+Status: ⚠️ degraded
+
+The implementation explicitly removes any incoming `streaming` field and always sends `streaming: false`.
+
+Impact:
+- callers cannot opt into streamed partial results through the SDK
+- the method only supports full-response behavior
+
+## 2. Base URL is hard-coded
+
+Status: ⚠️ limitation
+
+The client always targets:
+
+```txt
+https://api.desearch.ai
+```
+
+Impact:
+- no built-in support for staging, local development, or self-hosted API targets
+- testing alternate environments requires editing the SDK or mocking at a lower layer
+
+## 3. Error handling is string-based
+
+Status: ⚠️ degraded ergonomics
+
+HTTP failures throw plain `Error` instances with embedded status and response body text.
+
+Impact:
+- no typed SDK error hierarchy
+- downstream code must parse strings or inspect the original request context separately
+
+## 4. No timeout, retry, or abort controls
+
+Status: ⚠️ limitation
+
+The SDK calls `undici` fetch directly and does not expose:
+- timeout settings
+- retries
+- exponential backoff
+- abort signals
+
+Impact:
+- callers must implement reliability controls outside the SDK
+- long-running or rate-limited integrations need their own wrappers
+
+## 5. `xPostsByUrls` depends on repeated GET query parameters
+
+Status: ⚠️ compatibility caveat
+
+`xPostsByUrls` serializes `urls: string[]` into repeated query keys using `URLSearchParams`.
+
+Impact:
+- works only if the upstream API consistently accepts repeated `urls` parameters on a GET route
+- integrators debugging mismatches should inspect the final encoded URL first
+
+## 6. `AiSearchResponse` is intentionally loose
+
+Status: ⚠️ typing caveat
+
+The response type is:
+- `ResponseData`
+- `Record<string, unknown>`
+- `string`
+
+Impact:
+- TypeScript consumers do not get one stable response contract for `aiSearch`
+- callers may need runtime narrowing before reading fields safely
+
+## 7. Node-first transport choice
+
+Status: ⚠️ limitation
+
+The SDK imports `fetch` from `undici` directly.
+
+Impact:
+- the package is clearly optimized for Node runtimes
+- browser usage may need bundler shims or a different transport strategy depending on the app setup
+
+## 8. No write-side API coverage in this repo
+
+Status: ❌ missing feature
+
+The current public client only wraps read/search/crawl style endpoints.
+
+Impact:
+- if the wider Desearch platform grows mutation endpoints, this SDK does not expose them yet
+- consumers needing unsupported endpoints must call the HTTP API directly


### PR DESCRIPTION
Task ID: 58da55db-77a9-45f5-8846-ee1cf35aba24

Adds the desearch.js documentation knowledge base across README.md, docs/features.md, docs/architecture.md, and docs/known-issues.md, then follows up with README navigation improvements so the work is ready to merge in the repo itself.