### PR TITLE
Add opt-in response cost metadata support to Desearch JavaScript SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,32 @@ const page = await client.webCrawl({
 });
 ```
 
+### Optional response cost metadata
+
+SDK methods return the same raw payload shape by default:
+
+```ts
+const results = await client.webSearch({ query: 'desearch sdk' });
+console.log(results.data);
+```
+
+If you want per-request cost visibility, pass `{ includeMetadata: true }` as the second argument. The SDK reads metadata from the same API response headers; it does not make an extra billing or pricing request.
+
+```ts
+const response = await client.webSearch(
+  { query: 'desearch sdk' },
+  { includeMetadata: true },
+);
+
+console.log(response.data);
+console.log(response.metadata.costCents);
+console.log(response.metadata.usageCount);
+console.log(response.metadata.service);
+console.log(response.metadata.currency);
+```
+
+The metadata wrapper works for JSON object, JSON array, and text endpoints such as `webCrawl()`. Missing or malformed metadata headers are ignored, so successful API calls still resolve normally.
+
 ## Tech stack
 
 - TypeScript `^5.9.3`
@@ -210,6 +236,8 @@ Key design decisions in the current source:
 - GET payloads are serialized through `URLSearchParams`
 - POST payloads are serialized as JSON
 - response parsing switches between JSON and text based on `content-type`
+- default calls return the parsed payload directly, preserving the existing SDK response shape
+- callers can opt into `{ data, metadata }` wrappers with `{ includeMetadata: true }`
 - `webCrawl()` returns text while most other methods return JSON-shaped data
 - the base URL is fixed to `https://api.desearch.ai`
 - `aiSearch()` forcibly disables streaming

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,7 @@ This file contains:
 - the fixed `BASE_URL`
 - the `Desearch` class
 - the shared private `handleRequest<T>()` helper
+- response metadata parsing helpers for optional cost/usage visibility
 - all 13 public SDK methods
 
 Those public methods fall into three groups:
@@ -32,6 +33,7 @@ Those public methods fall into three groups:
 This file contains the exported type surface, including:
 - request interfaces
 - response interfaces
+- opt-in response metadata wrapper types
 - literal union types for API options
 - nested X tweet and user models
 - API error payload types
@@ -122,12 +124,42 @@ For POST requests, payloads are sent with:
 The helper checks `response.headers.get('content-type')`.
 
 Behavior:
-- if the content type contains `application/json`, the SDK returns `response.json()`
-- otherwise it returns `response.text()`
+- if the content type contains `application/json`, the SDK parses `response.json()`
+- otherwise it parses `response.text()`
+- by default, the parsed payload is returned directly
+- when a public method is called with `{ includeMetadata: true }`, the parsed payload is returned as `{ data, metadata }`
 
-This is why `webCrawl()` returns `Promise<string>` while most other methods return JSON-shaped data.
+This is why `webCrawl()` returns `Promise<string>` while most other methods return JSON-shaped data by default. The opt-in metadata wrapper also works for `webCrawl()` and JSON array endpoints because metadata is read from response headers instead of being merged into the response body.
 
-### 6. Error normalization
+### 6. Response cost metadata
+
+The SDK can expose per-request cost metadata without changing the default return shape. Each public method has overloads:
+- default call: `Promise<T>`
+- opt-in call with `{ includeMetadata: true }`: `Promise<DesearchResponse<T>>`
+
+The wrapper is:
+
+```ts
+{
+  data: T,
+  metadata: {
+    costCents?: number,
+    usageCount?: number,
+    service?: string,
+    currency?: string,
+  },
+}
+```
+
+Metadata comes from these response headers on the same API response:
+- `X-Desearch-Cost-Cents`
+- `X-Desearch-Usage-Count`
+- `X-Desearch-Service`
+- `X-Desearch-Currency`
+
+Numeric headers are parsed defensively. Missing, empty, or malformed values are omitted from `metadata` instead of throwing or failing an otherwise successful SDK call.
+
+### 7. Error normalization
 
 The helper uses two error paths:
 - HTTP failures become `Error('HTTP <status>: <body>')`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetch } from 'undici';
+import Desearch from './index';
+
+vi.mock('undici', () => ({
+  fetch: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetch);
+
+function mockResponse({
+  body,
+  contentType = 'application/json',
+  headers = {},
+  ok = true,
+  status = 200,
+}: {
+  body: unknown;
+  contentType?: string;
+  headers?: Record<string, string>;
+  ok?: boolean;
+  status?: number;
+}) {
+  const responseHeaders = new Map<string, string>([
+    ['content-type', contentType],
+  ]);
+  for (const [key, value] of Object.entries(headers)) {
+    responseHeaders.set(key.toLowerCase(), value);
+  }
+
+  mockedFetch.mockResolvedValueOnce({
+    ok,
+    status,
+    headers: {
+      get: (name: string) => responseHeaders.get(name.toLowerCase()) ?? null,
+    },
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(String(body)),
+  } as any);
+}
+
+describe('Desearch response metadata', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it('returns the raw JSON object payload by default even when cost headers are present', async () => {
+    const payload = {
+      data: [
+        {
+          title: 'Desearch',
+          snippet: 'AI search',
+          link: 'https://desearch.ai',
+        },
+      ],
+    };
+    mockResponse({
+      body: payload,
+      headers: {
+        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Usage-Count': '3',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(client.webSearch({ query: 'desearch' })).resolves.toEqual(
+      payload
+    );
+  });
+
+  it('returns the raw JSON array payload by default even when cost headers are present', async () => {
+    const payload = [
+      {
+        id: '1',
+        text: 'hello',
+        reply_count: 0,
+        retweet_count: 0,
+        like_count: 0,
+        quote_count: 0,
+        bookmark_count: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+    mockResponse({
+      body: payload,
+      headers: {
+        'X-Desearch-Cost-Cents': '1',
+        'X-Desearch-Usage-Count': '1',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(
+      client.xPostsByUrls({ urls: ['https://x.com/desearch/status/1'] })
+    ).resolves.toEqual(payload);
+  });
+
+  it('returns the raw text payload by default even when cost headers are present', async () => {
+    mockResponse({
+      body: 'plain crawled page',
+      contentType: 'text/plain',
+      headers: {
+        'X-Desearch-Cost-Cents': '0.25',
+        'X-Desearch-Usage-Count': '1',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(
+      client.webCrawl({ url: 'https://desearch.ai', format: 'text' })
+    ).resolves.toBe('plain crawled page');
+  });
+
+  it('returns data and parsed cost metadata when explicitly opted in', async () => {
+    const payload = {
+      data: [
+        {
+          title: 'Desearch',
+          snippet: 'AI search',
+          link: 'https://desearch.ai',
+        },
+      ],
+    };
+    mockResponse({
+      body: payload,
+      headers: {
+        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Usage-Count': '3',
+        'X-Desearch-Service': 'web-search',
+        'X-Desearch-Currency': 'USD',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(
+      client.webSearch({ query: 'desearch' }, { includeMetadata: true })
+    ).resolves.toEqual({
+      data: payload,
+      metadata: {
+        costCents: 2.5,
+        usageCount: 3,
+        service: 'web-search',
+        currency: 'USD',
+      },
+    });
+  });
+
+  it('returns metadata wrappers for JSON array endpoints when explicitly opted in', async () => {
+    const payload = [
+      {
+        id: '1',
+        text: 'hello',
+        reply_count: 0,
+        retweet_count: 0,
+        like_count: 0,
+        quote_count: 0,
+        bookmark_count: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+    mockResponse({
+      body: payload,
+      headers: {
+        'X-Desearch-Cost-Cents': '1.75',
+        'X-Desearch-Usage-Count': '2',
+        'X-Desearch-Service': 'twitter-urls',
+        'X-Desearch-Currency': 'USD',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(
+      client.xPostsByUrls(
+        { urls: ['https://x.com/desearch/status/1'] },
+        { includeMetadata: true }
+      )
+    ).resolves.toEqual({
+      data: payload,
+      metadata: {
+        costCents: 1.75,
+        usageCount: 2,
+        service: 'twitter-urls',
+        currency: 'USD',
+      },
+    });
+  });
+
+  it('returns undefined metadata fields for missing or malformed headers without breaking successful calls', async () => {
+    mockResponse({
+      body: 'plain crawled page',
+      contentType: 'text/plain',
+      headers: {
+        'X-Desearch-Cost-Cents': 'not-a-number',
+        'X-Desearch-Usage-Count': 'NaN',
+        'X-Desearch-Service': '',
+      },
+    });
+
+    const client = new Desearch('test-key');
+    await expect(
+      client.webCrawl({ url: 'https://desearch.ai' }, { includeMetadata: true })
+    ).resolves.toEqual({
+      data: 'plain crawled page',
+      metadata: {},
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import type {
   AiSearchRequest,
   AiSearchResponse,
   AiWebLinksSearchRequest,
+  DesearchCostMetadata,
+  DesearchDefaultRequestOptions,
+  DesearchMetadataRequestOptions,
+  DesearchRequestOptions,
+  DesearchResponse,
   WebSearchResponse,
   AiXLinksSearchRequest,
   XLinksSearchResponse,
@@ -35,7 +40,50 @@ class Desearch {
     this.apiKey = apiKey;
   }
 
-  private async handleRequest<T>(method: string, path: string, payload?: unknown): Promise<T> {
+  private parseResponseMetadata(headers: {
+    get(name: string): string | null;
+  }): DesearchCostMetadata {
+    const costCents = this.parseNumberHeader(
+      headers.get('x-desearch-cost-cents')
+    );
+    const usageCount = this.parseNumberHeader(
+      headers.get('x-desearch-usage-count')
+    );
+    const service = this.parseStringHeader(headers.get('x-desearch-service'));
+    const currency = this.parseStringHeader(headers.get('x-desearch-currency'));
+
+    return {
+      ...(costCents !== undefined ? { costCents } : {}),
+      ...(usageCount !== undefined ? { usageCount } : {}),
+      ...(service !== undefined ? { service } : {}),
+      ...(currency !== undefined ? { currency } : {}),
+    };
+  }
+
+  private parseNumberHeader(value: string | null): number | undefined {
+    if (value === null || value.trim() === '') {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  private parseStringHeader(value: string | null): string | undefined {
+    if (value === null) {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+  }
+
+  private async handleRequest<T>(
+    method: string,
+    path: string,
+    payload?: unknown,
+    options?: DesearchRequestOptions
+  ): Promise<T | DesearchResponse<T>> {
     try {
       let url = `${this.baseURL}${path}`;
       const headers: Record<string, string> = {
@@ -79,16 +127,27 @@ class Desearch {
       }
 
       const contentType = response.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        return (await response.json()) as T;
+      const data = contentType.includes('application/json')
+        ? ((await response.json()) as T)
+        : ((await response.text()) as unknown as T);
+
+      if (options?.includeMetadata) {
+        return {
+          data,
+          metadata: this.parseResponseMetadata(response.headers),
+        };
       }
 
-      return (await response.text()) as unknown as T;
+      return data;
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('HTTP ')) {
         throw error;
       }
-      throw new Error(`Unexpected Error: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Unexpected Error: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
@@ -96,143 +155,471 @@ class Desearch {
    * Perform an AI-powered multi-source contextual search across web, X, Reddit, YouTube, HackerNews, Wikipedia, and arXiv.
    *
    * @param payload - The search request parameters including prompt, tools, date filters, and result type.
-   * @returns Search results with optional AI-generated summaries.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns Search results with optional AI-generated summaries, or a metadata wrapper when opted in.
    */
-  async aiSearch(payload: AiSearchRequest): Promise<AiSearchResponse> {
-    const { streaming, ...rest } = payload as AiSearchRequest & { streaming?: boolean };
+  async aiSearch(
+    payload: AiSearchRequest,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<AiSearchResponse>>;
+  async aiSearch(
+    payload: AiSearchRequest,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<AiSearchResponse>;
+  async aiSearch(
+    payload: AiSearchRequest,
+    options: DesearchRequestOptions
+  ): Promise<AiSearchResponse | DesearchResponse<AiSearchResponse>>;
+  async aiSearch(
+    payload: AiSearchRequest,
+    options?: DesearchRequestOptions
+  ): Promise<AiSearchResponse | DesearchResponse<AiSearchResponse>> {
+    const { streaming, ...rest } = payload as AiSearchRequest & {
+      streaming?: boolean;
+    };
     const body = { ...rest, streaming: false };
-    return this.handleRequest<AiSearchResponse>('POST', '/desearch/ai/search', body);
+    return this.handleRequest<AiSearchResponse>(
+      'POST',
+      '/desearch/ai/search',
+      body,
+      options
+    );
   }
 
   /**
    * Search for raw links across web sources including web, HackerNews, Reddit, Wikipedia, YouTube, and arXiv.
    *
    * @param payload - The web links search request parameters including prompt, tools, and count.
-   * @returns Structured link results grouped by source.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns Structured link results grouped by source, or a metadata wrapper when opted in.
    */
-  async aiWebLinksSearch(payload: AiWebLinksSearchRequest): Promise<WebSearchResponse> {
-    return this.handleRequest<WebSearchResponse>('POST', '/desearch/ai/search/links/web', payload);
+  async aiWebLinksSearch(
+    payload: AiWebLinksSearchRequest,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<WebSearchResponse>>;
+  async aiWebLinksSearch(
+    payload: AiWebLinksSearchRequest,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<WebSearchResponse>;
+  async aiWebLinksSearch(
+    payload: AiWebLinksSearchRequest,
+    options: DesearchRequestOptions
+  ): Promise<WebSearchResponse | DesearchResponse<WebSearchResponse>>;
+  async aiWebLinksSearch(
+    payload: AiWebLinksSearchRequest,
+    options?: DesearchRequestOptions
+  ): Promise<WebSearchResponse | DesearchResponse<WebSearchResponse>> {
+    return this.handleRequest<WebSearchResponse>(
+      'POST',
+      '/desearch/ai/search/links/web',
+      payload,
+      options
+    );
   }
 
   /**
    * Search for X (Twitter) post links matching a prompt using AI-powered models.
    *
    * @param payload - The X links search request parameters including prompt and count.
-   * @returns Tweet objects matching the search prompt.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns Tweet objects matching the search prompt, or a metadata wrapper when opted in.
    */
-  async aiXLinksSearch(payload: AiXLinksSearchRequest): Promise<XLinksSearchResponse> {
-    return this.handleRequest<XLinksSearchResponse>('POST', '/desearch/ai/search/links/twitter', payload);
+  async aiXLinksSearch(
+    payload: AiXLinksSearchRequest,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<XLinksSearchResponse>>;
+  async aiXLinksSearch(
+    payload: AiXLinksSearchRequest,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<XLinksSearchResponse>;
+  async aiXLinksSearch(
+    payload: AiXLinksSearchRequest,
+    options: DesearchRequestOptions
+  ): Promise<XLinksSearchResponse | DesearchResponse<XLinksSearchResponse>>;
+  async aiXLinksSearch(
+    payload: AiXLinksSearchRequest,
+    options?: DesearchRequestOptions
+  ): Promise<XLinksSearchResponse | DesearchResponse<XLinksSearchResponse>> {
+    return this.handleRequest<XLinksSearchResponse>(
+      'POST',
+      '/desearch/ai/search/links/twitter',
+      payload,
+      options
+    );
   }
 
   /**
    * Search X (Twitter) with extensive filtering options including date range, user, language, verification, media type, and engagement thresholds.
    *
    * @param params - The search parameters including query, sort, user, date range, language, verification filters, media filters, engagement thresholds, and count.
-   * @returns An array of tweets matching the search criteria.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns An array of tweets matching the search criteria, or a metadata wrapper when opted in.
    */
-  async xSearch(params: XSearchParams): Promise<TwitterScraperTweet[] | Record<string, unknown>> {
-    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>('GET', '/twitter', params);
+  async xSearch(
+    params: XSearchParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>>;
+  async xSearch(
+    params: XSearchParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet[] | Record<string, unknown>>;
+  async xSearch(
+    params: XSearchParams,
+    options: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  >;
+  async xSearch(
+    params: XSearchParams,
+    options?: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  > {
+    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>(
+      'GET',
+      '/twitter',
+      params,
+      options
+    );
   }
 
   /**
    * Fetch full post data for a list of X (Twitter) post URLs.
    *
    * @param params - Object containing an array of post URLs to fetch.
-   * @returns An array of tweet objects with metadata, content, and engagement metrics.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns An array of tweet objects with metadata, content, and engagement metrics, or a metadata wrapper when opted in.
    */
-  async xPostsByUrls(params: XPostsByUrlsParams): Promise<TwitterScraperTweet[]> {
-    return this.handleRequest<TwitterScraperTweet[]>('GET', '/twitter/urls', params);
+  async xPostsByUrls(
+    params: XPostsByUrlsParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet[]>>;
+  async xPostsByUrls(
+    params: XPostsByUrlsParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet[]>;
+  async xPostsByUrls(
+    params: XPostsByUrlsParams,
+    options: DesearchRequestOptions
+  ): Promise<TwitterScraperTweet[] | DesearchResponse<TwitterScraperTweet[]>>;
+  async xPostsByUrls(
+    params: XPostsByUrlsParams,
+    options?: DesearchRequestOptions
+  ): Promise<TwitterScraperTweet[] | DesearchResponse<TwitterScraperTweet[]>> {
+    return this.handleRequest<TwitterScraperTweet[]>(
+      'GET',
+      '/twitter/urls',
+      params,
+      options
+    );
   }
 
   /**
    * Fetch a single X (Twitter) post by its unique ID.
    *
    * @param params - Object containing the post ID.
-   * @returns A tweet object with metadata, content, and engagement metrics.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns A tweet object with metadata, content, and engagement metrics, or a metadata wrapper when opted in.
    */
-  async xPostById(params: XPostByIdParams): Promise<TwitterScraperTweet> {
-    return this.handleRequest<TwitterScraperTweet>('GET', '/twitter/post', params);
+  async xPostById(
+    params: XPostByIdParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet>>;
+  async xPostById(
+    params: XPostByIdParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet>;
+  async xPostById(
+    params: XPostByIdParams,
+    options: DesearchRequestOptions
+  ): Promise<TwitterScraperTweet | DesearchResponse<TwitterScraperTweet>>;
+  async xPostById(
+    params: XPostByIdParams,
+    options?: DesearchRequestOptions
+  ): Promise<TwitterScraperTweet | DesearchResponse<TwitterScraperTweet>> {
+    return this.handleRequest<TwitterScraperTweet>(
+      'GET',
+      '/twitter/post',
+      params,
+      options
+    );
   }
 
   /**
    * Search X (Twitter) posts by a specific user with optional keyword filtering.
    *
    * @param params - Object containing user, optional query, and count.
-   * @returns An array of tweets posted by the specified user.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns An array of tweets posted by the specified user, or a metadata wrapper when opted in.
    */
-  async xPostsByUser(params: XPostsByUserParams): Promise<TwitterScraperTweet[] | Record<string, unknown>> {
-    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>('GET', '/twitter/post/user', params);
+  async xPostsByUser(
+    params: XPostsByUserParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>>;
+  async xPostsByUser(
+    params: XPostsByUserParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet[] | Record<string, unknown>>;
+  async xPostsByUser(
+    params: XPostsByUserParams,
+    options: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  >;
+  async xPostsByUser(
+    params: XPostsByUserParams,
+    options?: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  > {
+    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>(
+      'GET',
+      '/twitter/post/user',
+      params,
+      options
+    );
   }
 
   /**
    * Retrieve the list of users who retweeted a specific post by its ID.
    *
    * @param params - Object containing the post ID and optional cursor for pagination.
-   * @returns A list of users who retweeted the post with optional pagination cursor.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns A list of users who retweeted the post with optional pagination cursor, or a metadata wrapper when opted in.
    */
-  async xPostRetweeters(params: XPostRetweetersParams): Promise<XRetweetersResponse> {
-    return this.handleRequest<XRetweetersResponse>('GET', '/twitter/post/retweeters', params);
+  async xPostRetweeters(
+    params: XPostRetweetersParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<XRetweetersResponse>>;
+  async xPostRetweeters(
+    params: XPostRetweetersParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<XRetweetersResponse>;
+  async xPostRetweeters(
+    params: XPostRetweetersParams,
+    options: DesearchRequestOptions
+  ): Promise<XRetweetersResponse | DesearchResponse<XRetweetersResponse>>;
+  async xPostRetweeters(
+    params: XPostRetweetersParams,
+    options?: DesearchRequestOptions
+  ): Promise<XRetweetersResponse | DesearchResponse<XRetweetersResponse>> {
+    return this.handleRequest<XRetweetersResponse>(
+      'GET',
+      '/twitter/post/retweeters',
+      params,
+      options
+    );
   }
 
   /**
    * Retrieve a user's timeline posts by their username.
    *
    * @param params - Object containing the username and optional cursor for pagination.
-   * @returns The user's profile and their latest tweets with optional pagination cursor.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns The user's profile and their latest tweets with optional pagination cursor, or a metadata wrapper when opted in.
    */
-  async xUserPosts(params: XUserPostsParams): Promise<XUserPostsResponse> {
-    return this.handleRequest<XUserPostsResponse>('GET', '/twitter/user/posts', params);
+  async xUserPosts(
+    params: XUserPostsParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<XUserPostsResponse>>;
+  async xUserPosts(
+    params: XUserPostsParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<XUserPostsResponse>;
+  async xUserPosts(
+    params: XUserPostsParams,
+    options: DesearchRequestOptions
+  ): Promise<XUserPostsResponse | DesearchResponse<XUserPostsResponse>>;
+  async xUserPosts(
+    params: XUserPostsParams,
+    options?: DesearchRequestOptions
+  ): Promise<XUserPostsResponse | DesearchResponse<XUserPostsResponse>> {
+    return this.handleRequest<XUserPostsResponse>(
+      'GET',
+      '/twitter/user/posts',
+      params,
+      options
+    );
   }
 
   /**
    * Fetch tweets and replies posted by a specific user with optional keyword filtering.
    *
    * @param params - Object containing user, optional count, and optional query.
-   * @returns An array of tweets and replies by the specified user.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns An array of tweets and replies by the specified user, or a metadata wrapper when opted in.
    */
-  async xUserReplies(params: XUserRepliesParams): Promise<TwitterScraperTweet[] | Record<string, unknown>> {
-    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>('GET', '/twitter/replies', params);
+  async xUserReplies(
+    params: XUserRepliesParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>>;
+  async xUserReplies(
+    params: XUserRepliesParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet[] | Record<string, unknown>>;
+  async xUserReplies(
+    params: XUserRepliesParams,
+    options: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  >;
+  async xUserReplies(
+    params: XUserRepliesParams,
+    options?: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  > {
+    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>(
+      'GET',
+      '/twitter/replies',
+      params,
+      options
+    );
   }
 
   /**
    * Fetch replies to a specific X (Twitter) post by its post ID.
    *
    * @param params - Object containing the post ID, optional count, and optional query.
-   * @returns An array of reply tweets for the specified post.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns An array of reply tweets for the specified post, or a metadata wrapper when opted in.
    */
-  async xPostReplies(params: XPostRepliesParams): Promise<TwitterScraperTweet[] | Record<string, unknown>> {
-    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>('GET', '/twitter/replies/post', params);
+  async xPostReplies(
+    params: XPostRepliesParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>>;
+  async xPostReplies(
+    params: XPostRepliesParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<TwitterScraperTweet[] | Record<string, unknown>>;
+  async xPostReplies(
+    params: XPostRepliesParams,
+    options: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  >;
+  async xPostReplies(
+    params: XPostRepliesParams,
+    options?: DesearchRequestOptions
+  ): Promise<
+    | TwitterScraperTweet[]
+    | Record<string, unknown>
+    | DesearchResponse<TwitterScraperTweet[] | Record<string, unknown>>
+  > {
+    return this.handleRequest<TwitterScraperTweet[] | Record<string, unknown>>(
+      'GET',
+      '/twitter/replies/post',
+      params,
+      options
+    );
   }
 
   /**
    * Retrieve trending topics on X for a given location using its WOEID (Where On Earth ID).
    *
    * @param params - Object containing the WOEID and optional count.
-   * @returns Trending topics with optional location metadata.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns Trending topics with optional location metadata, or a metadata wrapper when opted in.
    */
-  async xTrends(params: XTrendsParams): Promise<XTrendsResponse> {
-    return this.handleRequest<XTrendsResponse>('GET', '/twitter/trends', params);
+  async xTrends(
+    params: XTrendsParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<XTrendsResponse>>;
+  async xTrends(
+    params: XTrendsParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<XTrendsResponse>;
+  async xTrends(
+    params: XTrendsParams,
+    options: DesearchRequestOptions
+  ): Promise<XTrendsResponse | DesearchResponse<XTrendsResponse>>;
+  async xTrends(
+    params: XTrendsParams,
+    options?: DesearchRequestOptions
+  ): Promise<XTrendsResponse | DesearchResponse<XTrendsResponse>> {
+    return this.handleRequest<XTrendsResponse>(
+      'GET',
+      '/twitter/trends',
+      params,
+      options
+    );
   }
 
   /**
    * Perform a SERP web search returning paginated web search results.
    *
    * @param params - Object containing the search query and optional pagination start offset.
-   * @returns Paginated web search results.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns Paginated web search results, or a metadata wrapper when opted in.
    */
-  async webSearch(params: WebSearchParams): Promise<WebSearchResultsResponse> {
-    return this.handleRequest<WebSearchResultsResponse>('GET', '/web', params);
+  async webSearch(
+    params: WebSearchParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<WebSearchResultsResponse>>;
+  async webSearch(
+    params: WebSearchParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<WebSearchResultsResponse>;
+  async webSearch(
+    params: WebSearchParams,
+    options: DesearchRequestOptions
+  ): Promise<
+    WebSearchResultsResponse | DesearchResponse<WebSearchResultsResponse>
+  >;
+  async webSearch(
+    params: WebSearchParams,
+    options?: DesearchRequestOptions
+  ): Promise<
+    WebSearchResultsResponse | DesearchResponse<WebSearchResultsResponse>
+  > {
+    return this.handleRequest<WebSearchResultsResponse>(
+      'GET',
+      '/web',
+      params,
+      options
+    );
   }
 
   /**
    * Crawl a URL and return its content as plain text or HTML.
    *
    * @param params - Object containing the URL to crawl and optional format (html or text).
-   * @returns The crawled content as a string.
+   * @param options - Optional SDK response options. Set `includeMetadata: true` to receive response cost metadata.
+   * @returns The crawled content as a string, or a metadata wrapper when opted in.
    */
-  async webCrawl(params: WebCrawlParams): Promise<string> {
-    return this.handleRequest<string>('GET', '/web/crawl', params);
+  async webCrawl(
+    params: WebCrawlParams,
+    options: DesearchMetadataRequestOptions
+  ): Promise<DesearchResponse<string>>;
+  async webCrawl(
+    params: WebCrawlParams,
+    options?: DesearchDefaultRequestOptions
+  ): Promise<string>;
+  async webCrawl(
+    params: WebCrawlParams,
+    options: DesearchRequestOptions
+  ): Promise<string | DesearchResponse<string>>;
+  async webCrawl(
+    params: WebCrawlParams,
+    options?: DesearchRequestOptions
+  ): Promise<string | DesearchResponse<string>> {
+    return this.handleRequest<string>('GET', '/web/crawl', params, options);
   }
 }
 
+export type * from './types';
 export default Desearch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,22 @@
 // Enums and Literal Types
 // ============================================================================
 
-export type ToolEnum = 'web' | 'hackernews' | 'reddit' | 'wikipedia' | 'youtube' | 'twitter' | 'arxiv';
+export type ToolEnum =
+  | 'web'
+  | 'hackernews'
+  | 'reddit'
+  | 'wikipedia'
+  | 'youtube'
+  | 'twitter'
+  | 'arxiv';
 
-export type WebToolEnum = 'web' | 'hackernews' | 'reddit' | 'wikipedia' | 'youtube' | 'arxiv';
+export type WebToolEnum =
+  | 'web'
+  | 'hackernews'
+  | 'reddit'
+  | 'wikipedia'
+  | 'youtube'
+  | 'arxiv';
 
 export type DateFilterEnum =
   | 'PAST_24_HOURS'
@@ -165,10 +178,63 @@ export interface WebCrawlParams {
 }
 
 // ============================================================================
+// Response Metadata Types
+// ============================================================================
+
+/** Cost and usage metadata parsed from Desearch response headers. */
+export interface DesearchCostMetadata {
+  /** Cost for the request, parsed from X-Desearch-Cost-Cents when present and numeric. */
+  costCents?: number;
+  /** Usage count for the request, parsed from X-Desearch-Usage-Count when present and numeric. */
+  usageCount?: number;
+  /** Service name for the charged request, parsed from X-Desearch-Service when present. */
+  service?: string;
+  /** Billing currency for the request, parsed from X-Desearch-Currency when present. */
+  currency?: string;
+}
+
+/** Wrapper returned when an SDK method is called with { includeMetadata: true }. */
+export interface DesearchResponse<T> {
+  /** The original response payload that default SDK calls return directly. */
+  data: T;
+  /** Optional per-request cost and usage metadata parsed from response headers. */
+  metadata: DesearchCostMetadata;
+}
+
+/** Request options that keep the default raw response payload shape. */
+export interface DesearchDefaultRequestOptions {
+  /** Leave unset or false to receive the raw response payload. */
+  includeMetadata?: false;
+}
+
+/** Request options overload that opts in to the metadata response wrapper. */
+export interface DesearchMetadataRequestOptions {
+  /** Return { data, metadata } instead of the raw response payload. */
+  includeMetadata: true;
+}
+
+/** SDK request options shared by all public methods. */
+export type DesearchRequestOptions =
+  | DesearchDefaultRequestOptions
+  | DesearchMetadataRequestOptions;
+
+/** Optional cost metadata fields that can appear in compatible JSON object bodies. */
+export interface DesearchCostMetadataBodyFields {
+  /** Request cost in cents when included by the API body. */
+  cost_cents?: number | null;
+  /** Request usage count when included by the API body. */
+  usage_count?: number | null;
+  /** Service name when included by the API body. */
+  service?: string | null;
+  /** Billing currency when included by the API body. */
+  currency?: string | null;
+}
+
+// ============================================================================
 // Response Types
 // ============================================================================
 
-export interface ResponseData {
+export interface ResponseData extends DesearchCostMetadataBodyFields {
   /** Search results from Hacker News */
   hacker_news_search?: Record<string, string | number>[] | null;
   /** Search results from Reddit */
@@ -199,7 +265,7 @@ export interface WebSearchResultItem {
   link: string;
 }
 
-export interface WebSearchResponse {
+export interface WebSearchResponse extends DesearchCostMetadataBodyFields {
   /** Youtube search results */
   youtube_search_results: WebSearchResultItem[] | null;
   /** Hacker News search results */
@@ -214,19 +280,19 @@ export interface WebSearchResponse {
   search_results: WebSearchResultItem[] | null;
 }
 
-export interface XLinksSearchResponse {
+export interface XLinksSearchResponse extends DesearchCostMetadataBodyFields {
   /** Miner tweets */
   miner_tweets: TwitterScraperTweet[];
 }
 
-export interface XRetweetersResponse {
+export interface XRetweetersResponse extends DesearchCostMetadataBodyFields {
   /** List of users who retweeted */
   users: TwitterScraperUser[];
   /** Cursor for pagination */
   next_cursor?: string | null;
 }
 
-export interface XUserPostsResponse {
+export interface XUserPostsResponse extends DesearchCostMetadataBodyFields {
   /** User profile information */
   user: TwitterScraperUser;
   /** User's tweets */
@@ -235,7 +301,7 @@ export interface XUserPostsResponse {
   next_cursor?: string | null;
 }
 
-export interface XTrendsResponse {
+export interface XTrendsResponse extends DesearchCostMetadataBodyFields {
   /** List of trending topics */
   trends: XTrendItem[];
   /** The location for which trends were retrieved */
@@ -258,7 +324,8 @@ export interface XTrendsWoeid {
   id: number;
 }
 
-export interface WebSearchResultsResponse {
+export interface WebSearchResultsResponse
+  extends DesearchCostMetadataBodyFields {
   /** Array of web search result items */
   data: WebSearchResultItem[];
 }


### PR DESCRIPTION
Files changed: src/index.ts adds shared header metadata parsing, preserves default raw payload returns, and adds opt-in overload/options for all public SDK methods; src/types.ts exports DesearchCostMetadata, DesearchResponse, request option types, and optional compatible body metadata fields; src/index.test.ts adds Vitest coverage for default JSON object, JSON array, and text payload shapes, opted-in object/array metadata wrappers, and missing/malformed header handling; README.md and docs/architecture.md document default behavior and opt-in cost metadata usage. Verification: npm test passed with 6 tests; npm run build passed with tsup and DTS generation. Noteworthy: metadata is read only from the same response headers, no extra API/billing request is made, invalid numeric headers are omitted instead of throwing, and existing HTTP error behavior is preserved. Commit: 98a5f55 feat(#1242): add opt-in response cost metadata.

---
Task: #1242 — Add opt-in response cost metadata support to Desearch JavaScript SDK
Opened automatically by mission-control dispatcher.