### PR TITLE
Update JS SDK request-cost metadata to USD

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ const response = await client.webSearch(
 );
 
 console.log(response.data);
-console.log(response.metadata.costCents);
+console.log(response.metadata.costUsd);
 console.log(response.metadata.usageCount);
 console.log(response.metadata.service);
 console.log(response.metadata.currency);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,7 +143,7 @@ The wrapper is:
 {
   data: T,
   metadata: {
-    costCents?: number,
+    costUsd?: number,
     usageCount?: number,
     service?: string,
     currency?: string,
@@ -152,7 +152,7 @@ The wrapper is:
 ```
 
 Metadata comes from these response headers on the same API response:
-- `X-Desearch-Cost-Cents`
+- `X-Desearch-Cost-Usd`
 - `X-Desearch-Usage-Count`
 - `X-Desearch-Service`
 - `X-Desearch-Currency`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,7 +57,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Cost-Usd': '2.5',
         'X-Desearch-Usage-Count': '3',
       },
     });
@@ -84,7 +84,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '1',
+        'X-Desearch-Cost-Usd': '1',
         'X-Desearch-Usage-Count': '1',
       },
     });
@@ -100,7 +100,7 @@ describe('Desearch response metadata', () => {
       body: 'plain crawled page',
       contentType: 'text/plain',
       headers: {
-        'X-Desearch-Cost-Cents': '0.25',
+        'X-Desearch-Cost-Usd': '0.25',
         'X-Desearch-Usage-Count': '1',
       },
     });
@@ -124,7 +124,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Cost-Usd': '2.5',
         'X-Desearch-Usage-Count': '3',
         'X-Desearch-Service': 'web-search',
         'X-Desearch-Currency': 'USD',
@@ -137,7 +137,7 @@ describe('Desearch response metadata', () => {
     ).resolves.toEqual({
       data: payload,
       metadata: {
-        costCents: 2.5,
+        costUsd: 2.5,
         usageCount: 3,
         service: 'web-search',
         currency: 'USD',
@@ -161,7 +161,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '1.75',
+        'X-Desearch-Cost-Usd': '1.75',
         'X-Desearch-Usage-Count': '2',
         'X-Desearch-Service': 'twitter-urls',
         'X-Desearch-Currency': 'USD',
@@ -177,7 +177,7 @@ describe('Desearch response metadata', () => {
     ).resolves.toEqual({
       data: payload,
       metadata: {
-        costCents: 1.75,
+        costUsd: 1.75,
         usageCount: 2,
         service: 'twitter-urls',
         currency: 'USD',
@@ -190,7 +190,7 @@ describe('Desearch response metadata', () => {
       body: 'plain crawled page',
       contentType: 'text/plain',
       headers: {
-        'X-Desearch-Cost-Cents': 'not-a-number',
+        'X-Desearch-Cost-Usd': 'not-a-number',
         'X-Desearch-Usage-Count': 'NaN',
         'X-Desearch-Service': '',
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ class Desearch {
   private parseResponseMetadata(headers: {
     get(name: string): string | null;
   }): DesearchCostMetadata {
+    const costUsd = this.parseNumberHeader(headers.get('x-desearch-cost-usd'));
     const costCents = this.parseNumberHeader(
       headers.get('x-desearch-cost-cents')
     );
@@ -53,6 +54,7 @@ class Desearch {
     const currency = this.parseStringHeader(headers.get('x-desearch-currency'));
 
     return {
+      ...(costUsd !== undefined ? { costUsd } : {}),
       ...(costCents !== undefined ? { costCents } : {}),
       ...(usageCount !== undefined ? { usageCount } : {}),
       ...(service !== undefined ? { service } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,9 @@ export interface WebCrawlParams {
 
 /** Cost and usage metadata parsed from Desearch response headers. */
 export interface DesearchCostMetadata {
-  /** Cost for the request, parsed from X-Desearch-Cost-Cents when present and numeric. */
+  /** Cost for the request in USD, parsed from X-Desearch-Cost-Usd when present and numeric. */
+  costUsd?: number;
+  /** @deprecated Use costUsd from X-Desearch-Cost-Usd instead. */
   costCents?: number;
   /** Usage count for the request, parsed from X-Desearch-Usage-Count when present and numeric. */
   usageCount?: number;
@@ -220,7 +222,9 @@ export type DesearchRequestOptions =
 
 /** Optional cost metadata fields that can appear in compatible JSON object bodies. */
 export interface DesearchCostMetadataBodyFields {
-  /** Request cost in cents when included by the API body. */
+  /** Request cost in USD when included by the API body. */
+  cost_usd?: number | null;
+  /** @deprecated Use cost_usd instead. */
   cost_cents?: number | null;
   /** Request usage count when included by the API body. */
   usage_count?: number | null;


### PR DESCRIPTION
## Problem
The JavaScript SDK still exposed and documented the old canonical request-cost metadata as cents (`x-desearch-cost-cents` / `costCents`) while Objective 90 makes USD metadata canonical (`x-desearch-cost-usd` / `cost_usd`).

## Root cause
The SDK parser, public TypeScript types, README example, architecture docs, and tests were all written around the earlier cents contract. The default SDK payload behavior already needed to stay unchanged.

## Fix
- Parse canonical `x-desearch-cost-usd` into SDK-native `metadata.costUsd`.
- Keep legacy `x-desearch-cost-cents` parsing only as deprecated compatibility via `metadata.costCents`.
- Update public types/body metadata docs to make `costUsd` / `cost_usd` canonical and mark cents fields deprecated.
- Update README and architecture docs to use USD metadata examples.
- Update tests for USD header parsing, malformed USD handling, and default return-shape preservation.

## Validation
- `npm test` passed: 1 test file, 6 tests.
- `npm run build` passed: tsup CJS/ESM/DTS output succeeded.
- `git status --short --branch` was clean after validation.

## Known gaps/blockers
None for the JS SDK task. Objective-level validation still needs the linked backend, Python SDK, docs, and cross-surface validation tasks to finish.

## Production expectation
After merge into `objective/o-90-cost-usd-response-metadata`, SDK users who opt into `{ includeMetadata: true }` receive `metadata.costUsd` from `x-desearch-cost-usd` without default return-shape changes. Main/prod/release remains gated on explicit Giga approval.
