### PR TITLE
Promote and release O-90 USD metadata in desearch.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ const response = await client.webSearch(
 );
 
 console.log(response.data);
-console.log(response.metadata.costCents);
+console.log(response.metadata.costUsd);
 console.log(response.metadata.usageCount);
 console.log(response.metadata.service);
 console.log(response.metadata.currency);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,7 +143,7 @@ The wrapper is:
 {
   data: T,
   metadata: {
-    costCents?: number,
+    costUsd?: number,
     usageCount?: number,
     service?: string,
     currency?: string,
@@ -152,7 +152,7 @@ The wrapper is:
 ```
 
 Metadata comes from these response headers on the same API response:
-- `X-Desearch-Cost-Cents`
+- `X-Desearch-Cost-Usd`
 - `X-Desearch-Usage-Count`
 - `X-Desearch-Service`
 - `X-Desearch-Currency`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desearch-js",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desearch-js",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desearch-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Desearch SDK for the Node.js",
   "publishConfig": {
     "access": "public"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,7 +57,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Cost-Usd': '2.5',
         'X-Desearch-Usage-Count': '3',
       },
     });
@@ -84,7 +84,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '1',
+        'X-Desearch-Cost-Usd': '1',
         'X-Desearch-Usage-Count': '1',
       },
     });
@@ -100,7 +100,7 @@ describe('Desearch response metadata', () => {
       body: 'plain crawled page',
       contentType: 'text/plain',
       headers: {
-        'X-Desearch-Cost-Cents': '0.25',
+        'X-Desearch-Cost-Usd': '0.25',
         'X-Desearch-Usage-Count': '1',
       },
     });
@@ -124,7 +124,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '2.5',
+        'X-Desearch-Cost-Usd': '2.5',
         'X-Desearch-Usage-Count': '3',
         'X-Desearch-Service': 'web-search',
         'X-Desearch-Currency': 'USD',
@@ -137,7 +137,7 @@ describe('Desearch response metadata', () => {
     ).resolves.toEqual({
       data: payload,
       metadata: {
-        costCents: 2.5,
+        costUsd: 2.5,
         usageCount: 3,
         service: 'web-search',
         currency: 'USD',
@@ -161,7 +161,7 @@ describe('Desearch response metadata', () => {
     mockResponse({
       body: payload,
       headers: {
-        'X-Desearch-Cost-Cents': '1.75',
+        'X-Desearch-Cost-Usd': '1.75',
         'X-Desearch-Usage-Count': '2',
         'X-Desearch-Service': 'twitter-urls',
         'X-Desearch-Currency': 'USD',
@@ -177,7 +177,7 @@ describe('Desearch response metadata', () => {
     ).resolves.toEqual({
       data: payload,
       metadata: {
-        costCents: 1.75,
+        costUsd: 1.75,
         usageCount: 2,
         service: 'twitter-urls',
         currency: 'USD',
@@ -190,7 +190,7 @@ describe('Desearch response metadata', () => {
       body: 'plain crawled page',
       contentType: 'text/plain',
       headers: {
-        'X-Desearch-Cost-Cents': 'not-a-number',
+        'X-Desearch-Cost-Usd': 'not-a-number',
         'X-Desearch-Usage-Count': 'NaN',
         'X-Desearch-Service': '',
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ class Desearch {
   private parseResponseMetadata(headers: {
     get(name: string): string | null;
   }): DesearchCostMetadata {
+    const costUsd = this.parseNumberHeader(headers.get('x-desearch-cost-usd'));
     const costCents = this.parseNumberHeader(
       headers.get('x-desearch-cost-cents')
     );
@@ -53,6 +54,7 @@ class Desearch {
     const currency = this.parseStringHeader(headers.get('x-desearch-currency'));
 
     return {
+      ...(costUsd !== undefined ? { costUsd } : {}),
       ...(costCents !== undefined ? { costCents } : {}),
       ...(usageCount !== undefined ? { usageCount } : {}),
       ...(service !== undefined ? { service } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,9 @@ export interface WebCrawlParams {
 
 /** Cost and usage metadata parsed from Desearch response headers. */
 export interface DesearchCostMetadata {
-  /** Cost for the request, parsed from X-Desearch-Cost-Cents when present and numeric. */
+  /** Cost for the request in USD, parsed from X-Desearch-Cost-Usd when present and numeric. */
+  costUsd?: number;
+  /** @deprecated Use costUsd from X-Desearch-Cost-Usd instead. */
   costCents?: number;
   /** Usage count for the request, parsed from X-Desearch-Usage-Count when present and numeric. */
   usageCount?: number;
@@ -220,7 +222,9 @@ export type DesearchRequestOptions =
 
 /** Optional cost metadata fields that can appear in compatible JSON object bodies. */
 export interface DesearchCostMetadataBodyFields {
-  /** Request cost in cents when included by the API body. */
+  /** Request cost in USD when included by the API body. */
+  cost_usd?: number | null;
+  /** @deprecated Use cost_usd instead. */
   cost_cents?: number | null;
   /** Request usage count when included by the API body. */
   usage_count?: number | null;


### PR DESCRIPTION
## Problem
Promote the approved O-90 JavaScript SDK USD request-cost metadata contract from the validated objective branch toward the normal `main`/release path for `Desearch-ai/desearch.js`.

## Root cause
The USD metadata implementation was validated on `objective/o-90-cost-usd-response-metadata` but had not yet been promoted to `main` or prepared for an npm package release. The package metadata also needed an explicit release-candidate version because npm already reports `desearch-js@1.3.0` as the current published version.

## Fix
- Verified Giga approval gate task #1785 before release-path work: status `done`, approved by `giga` at `2026-05-12T19:42:54.615+00:00`.
- Promoted the validated objective-branch SDK changes, including:
  - `src/index.ts`: parses `x-desearch-cost-usd` into opt-in `metadata.costUsd` while preserving default raw SDK returns.
  - `src/types.ts`: exposes native USD metadata fields and keeps cents names only as deprecated compatibility fields.
  - `src/index.test.ts`: covers unchanged default object/array/text returns, opt-in USD metadata wrappers, and malformed metadata headers.
  - `README.md` and `docs/architecture.md`: document the USD `costUsd` / `X-Desearch-Cost-Usd` contract.
- Added this-session release-prep commit `d255de8 chore(#1787): prepare O-90 metadata SDK release`.
- Bumped package metadata to `desearch-js@1.3.1` in `package.json` and `package-lock.json` so the approved metadata contract has a publishable patch version after merge.

## Validation
- Stack detected from `package.json`; used npm workflow.
- Approval check: task #1785 is `done`, `approved_by=giga`, approval comment `Approved ✅ — closure handler will run follow-ups before marking done`.
- Drift check: fetched `origin/main`; merge-base is `1d7367f4a71b58fa8e7402039664e3be0b34ed37`; promotion branch contains the validated O-90 commit plus the release-prep version bump only.
- Diff scope vs `origin/main`: `README.md`, `docs/architecture.md`, `src/index.test.ts`, `src/index.ts`, `src/types.ts`, `package.json`, `package-lock.json`.
- `npm ci` passed. Audit warning recorded separately: 6 vulnerabilities total (`3 moderate`, `3 high`), matching pre-existing dependency audit findings rather than O-90 behavior.
- `npm test` passed: `src/index.test.ts` 6/6 tests passed.
- `npm run build` passed: CJS, ESM, and DTS builds succeeded.
- `npm view desearch-js version --json` returned `1.3.0`; package files now prepare `1.3.1`.
- Grep check found no cents wording in README, architecture docs, or tests; remaining `costCents` / `cost_cents` references are source-only deprecated compatibility fields.

## Known gaps/blockers
- No npm publish, npm tag, git push, PR creation, or GitHub API action was performed from this worktree per dispatcher rules.
- PR URL and merge SHA are pending dispatcher PR creation/merge.
- Package publication remaining gate: after this PR is merged, release owner/automation should publish `desearch-js@1.3.1` and capture the npm package/tag refs.

## Production expectation
After merge, `main` should carry the approved O-90 JS SDK contract: default SDK calls continue returning the raw payload shape, while `{ includeMetadata: true }` returns `{ data, metadata }` with native USD `metadata.costUsd` from `X-Desearch-Cost-Usd`. After the separate npm publish step for `desearch-js@1.3.1`, external JS SDK users can consume the USD metadata contract from the released package.

---
Task: #1787 — Promote and release O-90 USD metadata in desearch.js
Opened automatically by mission-control dispatcher.