### PR TITLE
feat: add domain filters to AI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ const client = new Desearch(process.env.DESEARCH_API_KEY!);
 
 const result = await client.aiSearch({
   prompt: 'latest Bittensor developments',
-  tools: ['web', 'twitter', 'reddit'],
-  date_filter: 'PAST_24_HOURS',
+  tools: ['web'],
+  start_date: '2025-05-01T00:00:00Z',
+  end_date: '2025-05-08T00:00:00Z',
+  include_domains: ['bbc.com', 'reuters.com'],
   result_type: 'LINKS_WITH_FINAL_SUMMARY',
   count: 10,
 });
@@ -104,7 +106,8 @@ The SDK sends that value as the `Authorization` header on every request.
 ```ts
 const result = await client.aiSearch({
   prompt: 'recent AI chip announcements',
-  tools: ['web', 'hackernews', 'reddit', 'twitter'],
+  tools: ['web'],
+  exclude_domains: ['pinterest.com'],
   result_type: 'LINKS_WITH_FINAL_SUMMARY',
   count: 20,
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,10 @@ export interface AiSearchRequest {
   date_filter?: DateFilterEnum | null;
   /** The result type to be used for the search */
   result_type?: ResultTypeEnum | null;
+  /** Restrict Web Search results to these domains. */
+  include_domains?: string[] | null;
+  /** Drop Web Search results from these domains. */
+  exclude_domains?: string[] | null;
   /** The system message to be used for the search */
   system_message?: string | null;
   /** System message for scoring the response */


### PR DESCRIPTION
Adds the new AI search domain filters to the SDK, matching the public-api surface (`include_domains` / `exclude_domains`).

## Changes
- `AiSearchRequest` gains `include_domains?: string[] | null` and `exclude_domains?: string[] | null` (restrict / drop Web Search results by domain). `aiSearch()` already forwards the whole payload, so no runtime change is needed.
- README examples now show start/end dates + domain filters instead of the deprecated `date_filter` enum (still accepted; the API translates it to `start_date`/`end_date`).

Build + tests pass; `date_filter`, `start_date`, `end_date`, `result_type` were already present.
