### PR TITLE
chore: release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official JavaScript and TypeScript SDK for the Desearch public API.
 
-This repo publishes the npm package `desearch-js`. In the current source tree, the package version is `1.3.0`.
+This repo publishes the npm package `desearch-js`. In the current source tree, the package version is `1.4.0`.
 
 Related docs:
 - [docs/features.md](./docs/features.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desearch-js",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desearch-js",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desearch-js",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Desearch SDK for the Node.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bump for the AI-search domain filters merged in #10 (that PR was merged before the bump landed, so `main` is still on 1.3.1).

- `1.3.1` → `1.4.0` (minor: backward-compatible `include_domains`/`exclude_domains` addition)
- package.json + package-lock.json + README version string